### PR TITLE
generate bigwig genome coverage files to be displayed in Genome Browser

### DIFF
--- a/service-scripts/App-Variation.pl
+++ b/service-scripts/App-Variation.pl
@@ -273,6 +273,7 @@ sub process_variation_data {
         # system("cp $tmpdir/$_/var.annotated.raw.tsv $tmpdir/$_.var.annotated.tsv") if ! -s "$tmpdir/$_/var.annotated.tsv" && -s "$tmpdir/$_/var.annotated.raw.tsv";
         # system("cp $tmpdir/$_/var.snpEff.vcf $tmpdir/$_.var.snpEff.vcf") if -s "$tmpdir/$_/var.snpEff.vcf";
 
+        cp_if_present("$tmpdir/$_/cov.bigwig", "$tmpdir/$_.cov.bigwig");
         cp_if_present("$tmpdir/$_/var.vcf", "$tmpdir/$_.var.vcf");
         cp_if_present("$tmpdir/$_/var.vcf.gz", "$tmpdir/$_.var.vcf.gz");
         cp_if_present("$tmpdir/$_/var.vcf.gz.tbi", "$tmpdir/$_.var.vcf.gz.tbi");
@@ -368,6 +369,7 @@ sub process_variation_data {
     push @outputs, map { [ $_, 'vcf' ] } glob("$tmpdir/*.vcf");
     push @outputs, map { [ $_, 'html'] } glob("$tmpdir/*.html");
     push @outputs, map { [ $_, 'bam' ] } glob("$tmpdir/*.bam");
+    push @outputs, map { [ $_, 'bigwig' ] } glob("$tmpdir/*.bigwig");
     push @outputs, map { [ $_, 'contigs' ] } glob("$tmpdir/*.consensus.fa");
     push @outputs, map { [ $_, 'unspecified' ] } glob("$tmpdir/*.tbi $tmpdir/*.vcf.gz $tmpdir/*.bam.bai");
 

--- a/service-scripts/var-map.pl
+++ b/service-scripts/var-map.pl
@@ -166,7 +166,11 @@ sub compute_stats {
       # -s "depth"          or run("samtools depth aln.bam > depth");
       -s "depth"          or run("bedtools genomecov -ibam aln.bam -d > depth");
       -s "depth.hist"     or run("bedtools genomecov -ibam aln.bam > depth.hist");
+      -s "cov.bedgraph"   or run("bedtools genomecov -ibam aln.bam -bga > cov.bedgraph");
       -s "uncov.10"       or run("bedtools genomecov -ibam aln.bam -bga | perl -ne 'chomp; \@c=split/\t/; \$ln=\$c[2]-\$c[1]; print join(\"\\t\", \@c, \$ln).\"\\n\" if \$c[3]<10;' > uncov.10" );
+      -s "ref.fa.fai"     or run ("samtools faidx ref.fa");
+      -s "chrom.sizes"     or run ("cut -f1,2 ref.fa.fai > chrom.sizes");
+      -s "cov.bigwig"     or run ("bedGraphToBigWig cov.bedgraph chrom.sizes cov.bigwig");
       # BED start position 0-based and the end position 1-based (Example: NC_000962,1987085,1987701,0,616; the 0 coverage base really starts at 1987086)
     }
 }


### PR DESCRIPTION
This requires including the bedGraphToBigWig utility in the BV-BRC service app container. UCSC bedGraphToBigWig program converts a large, uncompressed bedGraph file into a compact, efficient BigWig for faster viewing in Genome Browser. Please see https://genome.ucsc.edu/goldenPath/help/bigWig.html for more information and check http://hgdownload.soe.ucsc.edu/admin/exe/ to see which one is suitable for BV-BRC servers.

I used this for testing:

wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig
chmod +x bedGraphToBigWig